### PR TITLE
Fix WMDEditor assignment error

### DIFF
--- a/jquery.wmd.js
+++ b/jquery.wmd.js
@@ -44,7 +44,7 @@
 })(jQuery);
 ;(function() {
     
-WMDEditor = function(options) {
+var WMDEditor = function(options) {
     this.options = WMDEditor.util.extend({}, WMDEditor.defaults, options || {});
     wmdBase(this, this.options);
 


### PR DESCRIPTION
Need to add `var` here to avoid assignment to undefined reference errors in some stricter clients.